### PR TITLE
Remove direct boto3 direct dependency

### DIFF
--- a/app/routers/configuration.py
+++ b/app/routers/configuration.py
@@ -4,7 +4,6 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from botocore.exceptions import InvalidRegionError
 from kubernetes import client, config as k8s_config
 from kubernetes.client.rest import ApiException
 
@@ -225,7 +224,7 @@ async def get_models(request: Request, llm_name: str):
                             status_code=status.HTTP_401_UNAUTHORIZED if response.status_code == 401 else status.HTTP_502_BAD_GATEWAY,
                             detail=f"Bedrock authentication failed. Make sure the Region and Bearer Token are valid and have the necessary permissions."
                         )
-            except InvalidRegionError as e:
+            except httpx.InvalidRegionError as e:
                 logging.error(f"Invalid AWS region: {e}")
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/routers/configuration.py
+++ b/app/routers/configuration.py
@@ -224,12 +224,6 @@ async def get_models(request: Request, llm_name: str):
                             status_code=status.HTTP_401_UNAUTHORIZED if response.status_code == 401 else status.HTTP_502_BAD_GATEWAY,
                             detail=f"Bedrock authentication failed. Make sure the Region and Bearer Token are valid and have the necessary permissions."
                         )
-            except httpx.InvalidRegionError as e:
-                logging.error(f"Invalid AWS region: {e}")
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid AWS region: {region}"
-                )
             except httpx.InvalidURL as e:
                 logging.error(f"Invalid region format for Bedrock URL: {e}")
                 raise HTTPException(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "psycopg[binary,pool]==3.3.5",
     "kopf==1.44.6",
     "authlib==1.8.0",
-    "boto3==1.43.82",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -248,16 +248,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.43.83"
+version = "1.43.89"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/6f/cf16418004c832e6eb9abc6905fa323a3bf96a76ca7f2e97858801a4103e/botocore-1.43.83.tar.gz", hash = "sha256:d9389b3b74400c34219965a2fb858c1d48744718865ee0496fd03bd5b21b943f", size = 16010078, upload-time = "2026-08-28T19:35:46.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/06/f63fb1befdf77af18539fb24ea01f2da0f13965ed5de091061708ac96416/botocore-1.43.89.tar.gz", hash = "sha256:f0574942970742657b0e0716cf08c2dfe6bef8e6de5fbb7081c3424e262b4cca", size = 16074206, upload-time = "2026-09-04T19:24:52.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/50/332d6713fa09b05ff0882f5d194569fa70d1c8735aca9829b1286fef32ba/botocore-1.43.83-py3-none-any.whl", hash = "sha256:bf75a6cf587c22d968e43e79fe122c39f82deafbe9c3422bc5d3e80b6210fc98", size = 15704489, upload-time = "2026-08-28T19:35:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9d/96f9dee6d12eedf1c2b4264eefd59c7ac8cac10daadb9a7bfccc9ee881c6/botocore-1.43.89-py3-none-any.whl", hash = "sha256:d7211220c815427fe71225acc6909e4ab5dfab3b03770e72fd16cf9eb86b3d1a", size = 15768272, upload-time = "2026-09-04T19:24:49.769Z" },
 ]
 
 [[package]]
@@ -3408,8 +3408,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -2947,7 +2947,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "asyncio" },
     { name = "authlib" },
-    { name = "boto3" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastmcp" },
     { name = "kopf" },
@@ -2980,7 +2979,6 @@ test = [
 requires-dist = [
     { name = "asyncio", specifier = "==4.0.0" },
     { name = "authlib", specifier = "==1.8.0" },
-    { name = "boto3", specifier = "==1.43.82" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.141.1" },
     { name = "fastmcp", specifier = "==3.4.7" },
     { name = "kopf", specifier = "==1.44.6" },


### PR DESCRIPTION
The boto3 dependency was largely removed in this PR https://github.com/rancher/rancher-ai-agent/pull/120

However, it wasn't removed from the `pyproject.toml` because we continued using a single error type from `botocore`. However, there is no `botocore` operation within the code anymore so it's not needed.

Note that it still exists in the `uv.lock` because it is an indirect dependency via `langchain-aws`, but now we aren't setting the version ourselves.